### PR TITLE
UMD version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,19 @@
   "name": "scribe-plugin-table-command",
   "version": "0.2.0",
   "description": "Table command for Scribe",
-  "main": "src/scribe-plugin-table-command.js",
+  "main": "dist/scribe-plugin-table-command.js",
+  "files" : [
+    "dist"
+  ],
   "scripts": {
     "build": "webpack && webpack --config webpack.config.min.js"
   },
-  "dependencies": {
-    "extract-text-webpack-plugin": "^0.3.8",
+  "devDependencies": {
     "css-loader": "^0.9.1",
+    "extract-text-webpack-plugin": "^0.3.8",
+    "nib": "^1.1.2",
     "style-loader": "^0.8.3",
+    "stylus": "^0.54.5",
     "stylus-loader": "^0.6.0",
     "webpack": "^1.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Table command for Scribe",
   "main": "dist/scribe-plugin-table-command.js",
-  "files" : [
+  "files": [
     "dist"
   ],
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
   output: {
     path: "build",
     filename: "scribe-plugin-table-command.js",
-    libraryTarget: "amd"
+    libraryTarget: "umd"
   },
   module: {
     loaders: [{

--- a/webpack.config.min.js
+++ b/webpack.config.min.js
@@ -6,7 +6,7 @@ module.exports = {
   output: {
     path: "build",
     filename: "scribe-plugin-table-command.min.js",
-    libraryTarget: "amd"
+    libraryTarget: "umd"
   },
   module: {
     loaders: [{


### PR DESCRIPTION
`package.json` tweaks:
- move all dependencies to development, they are not needed in production
- added missing dependencies on `nib` and `stylus` packages (build fails without them)
- only  publish `dist` directory on NPM (readme and license are automatically included by NPM)
- change `main` key to point to production version in `dist` directory

Also Webpack config changed to produce UMD build rather than just AMD.

Fixes #3

I didn't change version number, it seems like 0.3.0 might be a good one since it may cause minor issues for those who use sources rather than information from `main` key of `package.json`
