### PR TITLE
Made it possible to insert a table into an empty scribe editor

### DIFF
--- a/src/scribe-plugin-table-command.js
+++ b/src/scribe-plugin-table-command.js
@@ -28,7 +28,7 @@ module.exports = function() {
         var el = findBlockContainer(selection.range.endContainer);
         var nextElement = el.nextSibling;
 
-        if (nextElement) {
+        if (nextElement && scribe.el.contains(nextElement)) {
           scribe.el.insertBefore(tableElement, nextElement);
         }
 


### PR DESCRIPTION
 - When the scribe editor is empty `nextElement` may point to an element outside of the editor.
 - Added a `contains` check to guard against that.